### PR TITLE
feat: implement email queuing for invite and password reset notificat…

### DIFF
--- a/Modules/Admin/app/Notifications/ResetPasswordNotification.php
+++ b/Modules/Admin/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Admin\Notifications;
+
+use DateTimeInterface;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ResetPasswordNotification extends ResetPassword implements ShouldQueue
+{
+    public string $queue = 'notifications';
+
+    public ?string $connection = null;
+
+    public int|DateTimeInterface|null $delay = null;
+}

--- a/Modules/Admin/app/Notifications/VerifyEmailNotification.php
+++ b/Modules/Admin/app/Notifications/VerifyEmailNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Admin\Notifications;
+
+use DateTimeInterface;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class VerifyEmailNotification extends VerifyEmail implements ShouldQueue
+{
+    public string $queue = 'notifications';
+
+    public ?string $connection = null;
+
+    public int|DateTimeInterface|null $delay = null;
+}

--- a/Modules/Admin/tests/Feature/App/Http/Controllers/Auth/PasswordResetTest.php
+++ b/Modules/Admin/tests/Feature/App/Http/Controllers/Auth/PasswordResetTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
+use Modules\Admin\Notifications\ResetPasswordNotification;
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
@@ -18,7 +18,7 @@ test('reset password link can be requested', function () {
 
     post(route('password.request'), ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class);
+    Notification::assertSentTo($user, ResetPasswordNotification::class);
 });
 
 test('reset password screen can be rendered', function () {
@@ -28,7 +28,7 @@ test('reset password screen can be rendered', function () {
 
     post(route('password.request'), ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+    Notification::assertSentTo($user, ResetPasswordNotification::class, function ($notification) {
         get('/reset-password/'.$notification->token)->assertOk();
 
         return true;

--- a/Modules/Admin/tests/Feature/App/Http/Controllers/Auth/RegisteredUserControllerTest.php
+++ b/Modules/Admin/tests/Feature/App/Http/Controllers/Auth/RegisteredUserControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Support\Facades\Notification;
+use Modules\Admin\Notifications\VerifyEmailNotification;
 use Modules\Roles\Models\Role;
 
 use function Pest\Laravel\assertGuest;
@@ -112,7 +112,7 @@ test('users can register and receive only one email verification notification', 
 
     Notification::assertSentTo(
         [$user],
-        VerifyEmail::class,
+        VerifyEmailNotification::class,
         1
     );
 

--- a/Modules/Users/app/Livewire/Admin/Invite.php
+++ b/Modules/Users/app/Livewire/Admin/Invite.php
@@ -101,7 +101,7 @@ class Invite extends Component
             $user->assignRole($role);
         }
 
-        Mail::send(new SendInviteMail($user));
+        Mail::queue((new SendInviteMail($user))->onQueue('notifications'));
 
         add_user_log([
             'title' => 'invited '.$user->name,

--- a/Modules/Users/app/Livewire/Admin/Users.php
+++ b/Modules/Users/app/Livewire/Admin/Users.php
@@ -118,7 +118,7 @@ class Users extends Component
     public function resendInvite(string $id): void
     {
         $user = User::findOrFail($id);
-        Mail::send(new SendInviteMail($user));
+        Mail::queue((new SendInviteMail($user))->onQueue('notifications'));
 
         $user->invited_at = now();
         $user->save();

--- a/Modules/Users/tests/Feature/App/Livewire/Admin/InviteTest.php
+++ b/Modules/Users/tests/Feature/App/Livewire/Admin/InviteTest.php
@@ -78,7 +78,9 @@ test('send invite email on invite', function () {
         ->set('rolesSelected', ['editor'])
         ->call('store');
 
-    Mail::assertSent(SendInviteMail::class);
+    Mail::assertQueued(SendInviteMail::class, function ($mail) {
+        return $mail->onQueue('notifications');
+    });
 });
 
 test('name is required', function () {

--- a/Modules/Users/tests/Feature/App/Livewire/Admin/UsersTest.php
+++ b/Modules/Users/tests/Feature/App/Livewire/Admin/UsersTest.php
@@ -186,5 +186,7 @@ test('can resend invite', function () {
     Livewire::test(Users::class)
         ->call('resendInvite', $user->id);
 
-    Mail::assertSent(SendInviteMail::class);
+    Mail::assertQueued(SendInviteMail::class, function ($mail) {
+        return $mail->onQueue('notifications');
+    });
 });

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Modules\Admin\Notifications\ResetPasswordNotification;
+use Modules\Admin\Notifications\VerifyEmailNotification;
 use Modules\Users\Database\Factories\UserFactory;
 use Spatie\Permission\Traits\HasRoles;
 
@@ -97,5 +99,23 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         /** @var HasOne<User, User> */
         return $this->hasOne(User::class, 'id', 'invited_by');
+    }
+
+    /**
+     * Send the email verification notification.
+     */
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify((new VerifyEmailNotification));
+    }
+
+    /**
+     * Send the password reset notification.
+     *
+     * @param  string  $token
+     */
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify((new ResetPasswordNotification($token)));
     }
 }

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,0 +1,101 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Queue Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Laravel's queue API supports an assortment of back-ends via a single
+    | API, giving you convenient access to each back-end using the same
+    | syntax for every one. Here you may define a default connection.
+    |
+    */
+
+    'default' => env('QUEUE_CONNECTION', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the connection information for each server that
+    | is used by your application. A default configuration has been added
+    | for each back-end shipped with Laravel. You are free to add more.
+    |
+    | Drivers: "sync", "database", "beanstalkd", "sqs", "redis", "null"
+    |
+    */
+
+    'connections' => [
+
+        'sync' => [
+            'driver' => 'sync',
+        ],
+
+        'database' => [
+            'driver' => 'database',
+            'table' => 'jobs',
+            'queue' => 'default',
+            'retry_after' => 90,
+            'after_commit' => false,
+        ],
+
+        'notifications' => [
+            'driver' => 'database',
+            'table' => 'jobs',
+            'queue' => 'notifications',
+            'retry_after' => 90,
+            'after_commit' => false,
+        ],
+
+        'beanstalkd' => [
+            'driver' => 'beanstalkd',
+            'host' => 'localhost',
+            'queue' => 'default',
+            'retry_after' => 90,
+            'block_for' => 0,
+            'after_commit' => false,
+        ],
+
+        'sqs' => [
+            'driver' => 'sqs',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
+            'queue' => env('SQS_QUEUE', 'default'),
+            'suffix' => env('SQS_SUFFIX'),
+            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'after_commit' => false,
+        ],
+
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => 'default',
+            'queue' => env('REDIS_QUEUE', 'default'),
+            'retry_after' => 90,
+            'block_for' => null,
+            'after_commit' => false,
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Failed Queue Jobs
+    |--------------------------------------------------------------------------
+    |
+    | These options configure the behavior of failed queue job logging so you
+    | can control which database and table are used to store the jobs that
+    | have failed. You may change them to any database / table you wish.
+    |
+    */
+
+    'failed' => [
+        'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
+        'database' => env('DB_CONNECTION', 'mysql'),
+        'table' => 'failed_jobs',
+    ],
+
+];


### PR DESCRIPTION
This pull request introduces support for queueing notifications and emails in the `Modules/Admin` and `Modules/Users` modules. It includes the creation of custom notification classes, updates to tests, and the addition of a dedicated queue configuration for notifications. Below are the most important changes grouped by theme.

### Notification Queueing

* Created `ResetPasswordNotification` and `VerifyEmailNotification` classes in `Modules/Admin/Notifications`, which implement `ShouldQueue` and specify the `notifications` queue. [[1]](diffhunk://#diff-700fb67ccf9ec19528fad8a941c412078e38efce92c6e547a73ee80076b19415R1-R16) [[2]](diffhunk://#diff-c8314b27e7853c0fa6643e8efc6fd32f6806edd85bb42bf783acbd6558aff5f7R1-R16)
* Updated the `User` model to use the new notification classes and added methods for sending email verification and password reset notifications via the `notifications` queue. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR16-R17) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR103-R120)

### Email Queueing

* Updated `Mail::send` calls in `Modules/Users` to use `Mail::queue` with the `notifications` queue for sending invite emails. [[1]](diffhunk://#diff-629cdf0bb54725c30b08645a1638ed35cd106b9cc0380754d5a3e3452b283f13L104-R104) [[2]](diffhunk://#diff-76d37f52a03f51fbaecb177da8bf004a760bf33745e23a623dc6b76a1a12efbbL121-R121)

### Testing Updates

* Updated tests in `Modules/Admin` to verify the use of custom notification classes (`ResetPasswordNotification` and `VerifyEmailNotification`). [[1]](diffhunk://#diff-ee1d86429eddf34f6d6aabacb01015d473eaa9d7080a0e9d0f859481ba39ebe5L4-R5) [[2]](diffhunk://#diff-ee1d86429eddf34f6d6aabacb01015d473eaa9d7080a0e9d0f859481ba39ebe5L21-R21) [[3]](diffhunk://#diff-ee1d86429eddf34f6d6aabacb01015d473eaa9d7080a0e9d0f859481ba39ebe5L31-R31) [[4]](diffhunk://#diff-0ab5a0e81de462063bd3e20781117ba81e54fb36843b0a903ed483c1ef5b94f9L4-R5) [[5]](diffhunk://#diff-0ab5a0e81de462063bd3e20781117ba81e54fb36843b0a903ed483c1ef5b94f9L115-R115)
* Updated tests in `Modules/Users` to assert that invite emails are queued on the `notifications` queue. [[1]](diffhunk://#diff-17a34faff34081ae8ca5ce17cc8032e4e59da98284d185bdf8a3246e56af2449L81-R83) [[2]](diffhunk://#diff-872a01c66e1ecf584e6f270f0587293dd629f45a7984f2204e4fc9fb1cfb51b5L189-R191)

### Queue Configuration

* Added a dedicated `notifications` queue configuration in `config/queue.php` to separate notification jobs from other queued tasks.