### PR TITLE
Add link styles

### DIFF
--- a/Modules/Admin/resources/views/developer-reference.blade.php
+++ b/Modules/Admin/resources/views/developer-reference.blade.php
@@ -11,6 +11,7 @@
             <li><a class="text-primary" href="#error">Error</a></li>
             <li><a class="text-primary" href="#forms">Forms</a></li>
             <li><a class="text-primary" href="#alerts">Alerts</a></li>
+            <li><a class="text-primary" href="#links">Links</a></li>
             <li><a class="text-primary" href="#badges">Badges</a></li>
             <li><a class="text-primary" href="#buttons">Buttons</a></li>
             <li><a class="text-primary" href="#dropdown">Dropdown</a></li>
@@ -31,6 +32,7 @@
         @include('admin::docs.error')
         @include('admin::docs.forms')
         @include('admin::docs.alerts')
+        @include('admin::docs.links')
         @include('admin::docs.badges')
         @include('admin::docs.buttons')
         @include('admin::docs.dropdown')

--- a/Modules/Admin/resources/views/docs/alerts.blade.php
+++ b/Modules/Admin/resources/views/docs/alerts.blade.php
@@ -8,6 +8,10 @@
         </x-tabs.header>
 
         <x-tabs.div name="preview">
+
+            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink.</p>
+            <p>Primary is the default variant.</p>
+
             <x-alert>Primary</x-alert>
             <x-alert variant="gray">Gray</x-alert>
             <x-alert variant="red">Red</x-alert>
@@ -20,10 +24,6 @@
         </x-tabs.div>
 
         <x-tabs.div name="code">
-
-            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink.</p>
-            <p>Primary is the default variant.</p>
-
             <pre><code class="language-php">@php echo htmlentities('<x-alert>Primary</x-alert>
 <x-alert variant="gray">Gray</x-alert>
 <x-alert variant="red">Red</x-alert>

--- a/Modules/Admin/resources/views/docs/badges.blade.php
+++ b/Modules/Admin/resources/views/docs/badges.blade.php
@@ -8,6 +8,10 @@
         </x-tabs.header>
 
         <x-tabs.div name="preview">
+
+            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink.</p>
+            <p>Primary is the default variant.</p>
+
             <x-badge>Primary</x-badge>
             <x-badge variant="gray">Gray</x-badge>
             <x-badge variant="red">Red</x-badge>
@@ -20,10 +24,6 @@
         </x-tabs.div>
 
         <x-tabs.div name="code">
-
-            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink.</p>
-            <p>Primary is the default variant.</p>
-
             <pre><code class="language-php">@php echo htmlentities('<x-badge>Primary</x-badge>
 <x-badge variant="gray">Gray</x-badge>
 <x-badge variant="red">Red</x-badge>

--- a/Modules/Admin/resources/views/docs/buttons.blade.php
+++ b/Modules/Admin/resources/views/docs/buttons.blade.php
@@ -8,6 +8,10 @@
         </x-tabs.header>
 
         <x-tabs.div name="preview">
+
+            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink, link.</p>
+            <p>Primary is the default variant.</p>
+
             <p>Colours:</p>
             <x-button>Primary</x-button>
             <x-button variant="gray">Gray</x-button>
@@ -31,10 +35,7 @@
 
         <x-tabs.div name="code">
 
-            <p>Passing a variant will change the background color of the alert. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink, link.</p>
-            <p>Primary is the default variant.</p>
 
-            <p>Size Variants</p>
 
             <pre><code class="language-php">@php echo htmlentities('<x-button>Primary</x-button>
 <x-button variant="gray">Gray</x-button>

--- a/Modules/Admin/resources/views/docs/links.blade.php
+++ b/Modules/Admin/resources/views/docs/links.blade.php
@@ -1,0 +1,61 @@
+<div class="card">
+    <h2><a name="links">Links</a></h2>
+
+    <x-tabs name="preview">
+        <x-tabs.header>
+            <x-tabs.link name="preview">Preview</x-tabs.link>
+            <x-tabs.link name="code">Code</x-tabs.link>
+        </x-tabs.header>
+
+        <x-tabs.div name="preview">
+            <x-a href="#">Primary</x-a>
+            <x-a href="#" variant="gray">Gray</x-a>
+            <x-a href="#" variant="red">Red</x-a>
+            <x-a href="#" variant="yellow">Yellow</x-a>
+            <x-a href="#" variant="green">Green</x-a>
+            <x-a href="#" variant="blue">Blue</x-a>
+            <x-a href="#" variant="indigo">Indigo</x-a>
+            <x-a href="#" variant="purple">Purple</x-a>
+            <x-a href="#" variant="pink">Pink</x-a>
+            <x-a href="#" variant="link">Link Style</x-a>
+
+            <div class="mt-4">
+                <x-a href="#" size="xs">Extra Small</x-a>
+                <x-a href="#" size="sm">Small</x-a>
+                <x-a href="#">Default</x-a>
+                <x-a href="#" size="lg">Large</x-a>
+                <x-a href="#" size="xl">Extra Large</x-a>
+            </div>
+        </x-tabs.div>
+
+        <x-tabs.div name="code">
+            <p>The <code>x-a</code> component is a styled anchor tag that supports the same color variants and sizes as the button component.</p>
+
+            <p>Passing a variant will change the background color of the link. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink, and link.</p>
+            <p>Primary is the default variant.</p>
+
+            <pre><code class="language-php">@php echo htmlentities('<x-a href="#">Primary</x-a>
+<x-a href="#" variant="gray">Gray</x-a>
+<x-a href="#" variant="red">Red</x-a>
+<x-a href="#" variant="yellow">Yellow</x-a>
+<x-a href="#" variant="green">Green</x-a>
+<x-a href="#" variant="blue">Blue</x-a>
+<x-a href="#" variant="indigo">Indigo</x-a>
+<x-a href="#" variant="purple">Purple</x-a>
+<x-a href="#" variant="pink">Pink</x-a>
+<x-a href="#" variant="link">Link Style</x-a>') @endphp</code></pre>
+
+            <p class="mt-4">You can also specify different sizes:</p>
+
+            <pre><code class="language-php">@php echo htmlentities('<x-a href="#" size="xs">Extra Small</x-a>
+<x-a href="#" size="sm">Small</x-a>
+<x-a href="#">Default</x-a>
+<x-a href="#" size="lg">Large</x-a>
+<x-a href="#" size="xl">Extra Large</x-a>') @endphp</code></pre>
+
+            <p class="mt-4">By default, links include <code>wire:navigate</code> for SPA navigation. You can disable this with the navigate prop:</p>
+
+            <pre><code class="language-php">@php echo htmlentities('<x-a href="#" :navigate="false">Link without wire:navigate</x-a>') @endphp</code></pre>
+        </x-tabs.div>
+    </x-tabs>
+</div>

--- a/Modules/Admin/resources/views/docs/links.blade.php
+++ b/Modules/Admin/resources/views/docs/links.blade.php
@@ -8,6 +8,12 @@
         </x-tabs.header>
 
         <x-tabs.div name="preview">
+
+            <p>The <code>x-a</code> component is a styled anchor tag that supports the same color variants and sizes as the button component.</p>
+
+            <p>Passing a variant will change the background color of the link. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink, and link.</p>
+            <p>Primary is the default variant.</p>
+
             <x-a href="#">Primary</x-a>
             <x-a href="#" variant="gray">Gray</x-a>
             <x-a href="#" variant="red">Red</x-a>
@@ -20,6 +26,7 @@
             <x-a href="#" variant="link">Link Style</x-a>
 
             <div class="mt-4">
+                <p class="mt-5">Sizes:</p>
                 <x-a href="#" size="xs">Extra Small</x-a>
                 <x-a href="#" size="sm">Small</x-a>
                 <x-a href="#">Default</x-a>
@@ -29,11 +36,6 @@
         </x-tabs.div>
 
         <x-tabs.div name="code">
-            <p>The <code>x-a</code> component is a styled anchor tag that supports the same color variants and sizes as the button component.</p>
-
-            <p>Passing a variant will change the background color of the link. The available variants are: gray, red, yellow, green, blue, indigo, purple, pink, and link.</p>
-            <p>Primary is the default variant.</p>
-
             <pre><code class="language-php">@php echo htmlentities('<x-a href="#">Primary</x-a>
 <x-a href="#" variant="gray">Gray</x-a>
 <x-a href="#" variant="red">Red</x-a>

--- a/composer.lock
+++ b/composer.lock
@@ -1407,16 +1407,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.13.0",
+            "version": "v12.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "52b588bcd8efc6d01bc1493d2d67848f8065f269"
+                "reference": "2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/52b588bcd8efc6d01bc1493d2d67848f8065f269",
-                "reference": "52b588bcd8efc6d01bc1493d2d67848f8065f269",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77",
+                "reference": "2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77",
                 "shasum": ""
             },
             "require": {
@@ -1618,7 +1618,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-05-07T17:29:01+00:00"
+            "time": "2025-05-20T15:10:44+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -4093,16 +4093,16 @@
         },
         {
             "name": "spatie/laravel-permission",
-            "version": "6.17.0",
+            "version": "6.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-permission.git",
-                "reference": "02ada8f638b643713fa2fb543384738e27346ddb"
+                "reference": "3c05f04d12275dfbe462c8b4aae3290e586c2dde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/02ada8f638b643713fa2fb543384738e27346ddb",
-                "reference": "02ada8f638b643713fa2fb543384738e27346ddb",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/3c05f04d12275dfbe462c8b4aae3290e586c2dde",
+                "reference": "3c05f04d12275dfbe462c8b4aae3290e586c2dde",
                 "shasum": ""
             },
             "require": {
@@ -4164,7 +4164,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-permission/issues",
-                "source": "https://github.com/spatie/laravel-permission/tree/6.17.0"
+                "source": "https://github.com/spatie/laravel-permission/tree/6.18.0"
             },
             "funding": [
                 {
@@ -4172,7 +4172,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-08T15:06:14+00:00"
+            "time": "2025-05-14T03:32:23+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7753,16 +7753,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.42.0",
+            "version": "v1.43.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "2edaaf77f3c07a4099965bb3d7dfee16e801c0f6"
+                "reference": "71a509b14b2621ce58574274a74290f933c687f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/2edaaf77f3c07a4099965bb3d7dfee16e801c0f6",
-                "reference": "2edaaf77f3c07a4099965bb3d7dfee16e801c0f6",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/71a509b14b2621ce58574274a74290f933c687f7",
+                "reference": "71a509b14b2621ce58574274a74290f933c687f7",
                 "shasum": ""
             },
             "require": {
@@ -7812,7 +7812,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2025-04-29T14:26:46+00:00"
+            "time": "2025-05-13T13:34:34+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -8864,16 +8864,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.14",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8f2e03099cac24ff3b379864d171c5acbfc6b9a2"
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f2e03099cac24ff3b379864d171c5acbfc6b9a2",
-                "reference": "8f2e03099cac24ff3b379864d171c5acbfc6b9a2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
                 "shasum": ""
             },
             "require": {
@@ -8918,7 +8918,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-02T15:32:28+00:00"
+            "time": "2025-05-21T20:55:28+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -9721,23 +9721,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.0",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
-                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^11.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -9773,15 +9773,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:54:44+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",

--- a/resources/views/components/a.blade.php
+++ b/resources/views/components/a.blade.php
@@ -1,6 +1,37 @@
+@props([
+    'navigate' => true,
+])
+
+@php
+$class = "inline-flex items-center font-medium ease-in-out disabled:opacity-50
+disabled:cursor-not-allowed disabled:opacity-50 rounded-md cursor-pointer ";
+
+$class .= " " . match($attributes->get("variant")) {
+    default => "bg-primary text-white hover:bg-primary/90 shadow-md dark:bg-primary-dark dark:text-gray-200 dark:hover:bg-primary-dark/80",
+    'gray' => "bg-gray-200 text-gray-700 hover:bg-gray-300/90 shadow-md dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700/90",
+    'red' => "bg-red-500 text-red-200 hover:bg-red-500/90 shadow-md dark:bg-red-700 dark:text-red-100 dark:hover:bg-red-600/90",
+    'yellow' => "bg-yellow-500 text-yellow-200 hover:bg-yellow-500/90 shadow-md dark:bg-yellow-600 dark:text-yellow-100 dark:hover:bg-yellow-500/90",
+    'green' => "bg-green-500 text-green-200 hover:bg-green-500/90 shadow-md dark:bg-green-700 dark:text-green-100 dark:hover:bg-green-600/90",
+    'blue' => "bg-blue-500 text-blue-200 hover:bg-blue-500/90 shadow-md dark:bg-blue-700 dark:text-blue-100 dark:hover:bg-blue-600/90",
+    'indigo' => "bg-indigo-500 text-indigo-200 hover:bg-indigo-500/90 shadow-md dark:bg-indigo-700 dark:text-indigo-100 dark:hover:bg-indigo-600/90",
+    'purple' => "bg-purple-500 text-purple-200 hover:bg-purple-500/90 shadow-md dark:bg-purple-700 dark:text-purple-100 dark:hover:bg-purple-600/90",
+    'pink' => "bg-pink-500 text-pink-200 hover:bg-pink-500/90 shadow-md dark:bg-pink-700 dark:text-pink-100 dark:hover:bg-pink-600/90",
+    'link' => "text-primary underline-offset-4 hover:underline dark:text-primary-light"
+};
+
+$class .= " " . match($attributes->get("size")){
+    default => "px-4 py-2",
+    'xs' => "px-2 py-1 text-sm",
+    'sm' => "px-3 py-2 text-sm",
+    'lg' => "px-6 py-3",
+    'xl' => "px-8 py-4 ",
+    'icon' => "size-10"
+};
+@endphp
+
 <a
-    {{ $attributes->except('wire:navigate') }}
-    wire:navigate
+    {{ $attributes->merge(["class" => $class])->except(['size', 'variant', 'navigate']) }}
+    @if($navigate) wire:navigate @endif
 >
     {{ $slot }}
 </a>

--- a/tests/Unit/resources/views/components/ATest.php
+++ b/tests/Unit/resources/views/components/ATest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+test('renders with default props', function () {
+    $rendered = Blade::render('<x-a href="#">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain('href="#"')
+        ->toContain('wire:navigate')
+        ->toContain('Link Text');
+});
+
+test('renders without wire:navigate when navigate is false', function () {
+    $rendered = Blade::render('<x-a href="#" :navigate="false">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain('href="#"')
+        ->not->toContain('wire:navigate')
+        ->toContain('Link Text');
+});
+
+test('renders with different variants', function ($variant, $expectedClass) {
+    $rendered = Blade::render('<x-a href="#" variant="' . $variant . '">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain($expectedClass);
+})->with([
+    ['gray', 'bg-gray-200'],
+    ['red', 'bg-red-500'],
+    ['yellow', 'bg-yellow-500'],
+    ['green', 'bg-green-500'],
+    ['blue', 'bg-blue-500'],
+    ['indigo', 'bg-indigo-500'],
+    ['purple', 'bg-purple-500'],
+    ['pink', 'bg-pink-500'],
+    ['link', 'text-primary'],
+]);
+
+test('renders with different sizes', function ($size, $expectedClass) {
+    $rendered = Blade::render('<x-a href="#" size="' . $size . '">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain($expectedClass);
+})->with([
+    ['xs', 'px-2 py-1 text-sm'],
+    ['sm', 'px-3 py-2 text-sm'],
+    ['lg', 'px-6 py-3'],
+    ['xl', 'px-8 py-4'],
+    ['icon', 'size-10'],
+]);
+
+test('merges classes correctly', function () {
+    $rendered = Blade::render('<x-a href="#" class="custom-class">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain('class="')
+        ->toContain('custom-class');
+});
+
+test('passes through other attributes', function () {
+    $rendered = Blade::render('<x-a href="#" id="my-link" data-test="value">Link Text</x-a>');
+
+    expect($rendered)
+        ->toContain('id="my-link"')
+        ->toContain('data-test="value"');
+});

--- a/tests/Unit/resources/views/components/ATest.php
+++ b/tests/Unit/resources/views/components/ATest.php
@@ -21,7 +21,7 @@ test('renders without wire:navigate when navigate is false', function () {
 });
 
 test('renders with different variants', function ($variant, $expectedClass) {
-    $rendered = Blade::render('<x-a href="#" variant="' . $variant . '">Link Text</x-a>');
+    $rendered = Blade::render('<x-a href="#" variant="'.$variant.'">Link Text</x-a>');
 
     expect($rendered)
         ->toContain($expectedClass);
@@ -38,7 +38,7 @@ test('renders with different variants', function ($variant, $expectedClass) {
 ]);
 
 test('renders with different sizes', function ($size, $expectedClass) {
-    $rendered = Blade::render('<x-a href="#" size="' . $size . '">Link Text</x-a>');
+    $rendered = Blade::render('<x-a href="#" size="'.$size.'">Link Text</x-a>');
 
     expect($rendered)
         ->toContain($expectedClass);


### PR DESCRIPTION
This pull request introduces a new `x-a` component for styled links, updates the developer reference documentation to include it, and enhances the documentation for existing components (`alerts`, `badges`, and `buttons`) with better descriptions of variants and sizes. It also includes unit tests for the new component. Below is a summary of the most important changes:

### New `x-a` Component for Links:
* Added a new `x-a` component in `resources/views/components/a.blade.php` to provide a styled anchor tag with support for color variants, size options, and SPA navigation (`wire:navigate`).
* Created a new documentation page for the `x-a` component in `Modules/Admin/resources/views/docs/links.blade.php`, detailing its usage, available variants, and sizes.
* Added unit tests in `tests/Unit/resources/views/components/ATest.php` to verify the functionality of the `x-a` component, including default props, variants, sizes, and attribute merging.

### Updates to Developer Reference:
* Updated the developer reference navigation in `Modules/Admin/resources/views/developer-reference.blade.php` to include the new "Links" section. [[1]](diffhunk://#diff-4b72e25e18a9dbbc38167de6eb1ee752aeb3c4d52b3e05557127fcbd6bc4b5c2R14) [[2]](diffhunk://#diff-4b72e25e18a9dbbc38167de6eb1ee752aeb3c4d52b3e05557127fcbd6bc4b5c2R35)

### Enhancements to Component Documentation:
* Improved the `alerts`, `badges`, and `buttons` documentation by adding descriptions of the available variants and sizes in their respective `preview` sections and removing redundant descriptions from the `code` sections:
  - `Modules/Admin/resources/views/docs/alerts.blade.php` [[1]](diffhunk://#diff-d33ec71863a21933b957cc8a7e89a5089a49ef4cdbb74ce703ff3f3d2a8f5471R11-R14) [[2]](diffhunk://#diff-d33ec71863a21933b957cc8a7e89a5089a49ef4cdbb74ce703ff3f3d2a8f5471L23-L26)
  - `Modules/Admin/resources/views/docs/badges.blade.php` [[1]](diffhunk://#diff-ddd8be6f6ce7bb328f4b7b26bd473190e91462ae6a8b89b519fc0dae1a62afb9R11-R14) [[2]](diffhunk://#diff-ddd8be6f6ce7bb328f4b7b26bd473190e91462ae6a8b89b519fc0dae1a62afb9L23-L26)
  - `Modules/Admin/resources/views/docs/buttons.blade.php` [[1]](diffhunk://#diff-859c1196afc7dafb99c9c336992432b82e65b032c0414354e261d6832928aec4R11-R14) [[2]](diffhunk://#diff-859c1196afc7dafb99c9c336992432b82e65b032c0414354e261d6832928aec4L34-L37)